### PR TITLE
fixed bug not show "Aligned bases in genome"

### DIFF
--- a/multiqc/modules/dragen/coverage_metrics.py
+++ b/multiqc/modules/dragen/coverage_metrics.py
@@ -31,7 +31,6 @@ class DragenCoverageMetrics(BaseMultiqcModule):
 
         # Filter to strip out ignored sample names:
         data_by_phenotype_by_sample = self.ignore_samples(data_by_phenotype_by_sample)
-
         # Merge tumor and normal data:
         data_by_sample = defaultdict(dict)
         for sn in data_by_phenotype_by_sample:
@@ -40,10 +39,8 @@ class DragenCoverageMetrics(BaseMultiqcModule):
                 if phenotype == "normal":
                     new_sn = sn + "_normal"
                 data_by_sample[new_sn] = data_by_phenotype_by_sample[sn][phenotype]
-
         if not data_by_sample:
             return set()
-
         all_metric_names = set()
         for sn, sdata in data_by_sample.items():
             for m in sdata.keys():
@@ -119,7 +116,7 @@ COV_METRICS = list(
                 # Read stats:
                 Metric("Aligned reads", "Aln reads", "hid", "#", "reads", "Total number of aligned reads."),
                 Metric(
-                    "Aligned reads in region",
+                    "Aligned reads in {}",
                     "Reads on trg",
                     "hid",
                     "%",
@@ -128,7 +125,7 @@ COV_METRICS = list(
                 ),
                 Metric("Aligned bases", "Aln bases", "hid", "#", "bases", "Total number of aligned bases."),
                 Metric(
-                    "Aligned bases in region",
+                    "Aligned bases in {}",
                     "Bases on trg",
                     "hid",
                     "%",


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated

<!-- If this PR is for a NEW module - delete if not -->

- [ ] There is example tool output for tools in the https://github.com/ewels/MultiQC_TestData repository or attached to this PR
- [ ] Code is tested and works locally (including with `--lint` flag)
- [ ] `docs/README.md` is updated with link to below
- [ ] `docs/modulename.md` is created
- [ ] Everything that can be represented with a plot instead of a table is a plot
- [ ] Report sections have a description and help text (with `self.add_section`)
- [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [ ] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
- [ ] Module does not do any significant computational work
